### PR TITLE
Update @userfront/core to 0.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@anymod/core": "^0.1.51",
         "@userfront/core": "^0.5.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.2",
       "dependencies": {
         "@anymod/core": "^0.1.51",
-        "@userfront/core": "^0.5.1"
+        "@userfront/core": "^0.5.6"
       },
       "devDependencies": {
         "@babel/core": "^7.12.3",
@@ -2956,9 +2956,9 @@
       "dev": true
     },
     "node_modules/@userfront/core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.1.tgz",
-      "integrity": "sha512-wV9BUjuxK+ujrZ4iiGtzfmLum3nOGTIP6eGnV2y5MiESktObrj2/DsaVr3qQ5OCBhF0qqvdjAz/HE0OFu6ZrIg==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.6.tgz",
+      "integrity": "sha512-Ge8b+1DzmlKt1+/N4ySgEM29RXzwysV0JtsB51EZVNksDAojQVvx6pB9Yh10D4xGj4/GoiGUbbs6XNv0ktIyKw==",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"
@@ -15453,9 +15453,9 @@
       "dev": true
     },
     "@userfront/core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.1.tgz",
-      "integrity": "sha512-wV9BUjuxK+ujrZ4iiGtzfmLum3nOGTIP6eGnV2y5MiESktObrj2/DsaVr3qQ5OCBhF0qqvdjAz/HE0OFu6ZrIg==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.6.tgz",
+      "integrity": "sha512-Ge8b+1DzmlKt1+/N4ySgEM29RXzwysV0JtsB51EZVNksDAojQVvx6pB9Yh10D4xGj4/GoiGUbbs6XNv0ktIyKw==",
       "requires": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/userfront/userfront-react#readme",
   "dependencies": {
     "@anymod/core": "^0.1.51",
-    "@userfront/core": "^0.5.1"
+    "@userfront/core": "^0.5.6"
   },
   "peerDependencies": {
     "react": "^16 || ^17 || ^18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/react",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Userfront React binding",
   "source": "src/index.js",
   "main": "build/userfront-react.js",


### PR DESCRIPTION
Glance
Ref https://github.com/userfront/userfront-core/issues/133

- Update `@userfront/core` dependency to 0.5.6
- Update own version number to 0.3.3

(Already published.)